### PR TITLE
feat(rhel_9): adding RHEL9 support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install test dependencies
         run: pip install ansible-lint[community,yamllint]
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install test dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           - distro: ubi8
             platform: instance-r-rh
             ansible-version: '>=2.11.5'
+          - distro: ubi9
+            platform: instance-r-rh
+            ansible-version: '>=2.11.5'
 
     steps:
       - name: Check out the codebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,10 @@ jobs:
       matrix:
         include:
           - distro: ubuntu2004
-            ansible-version: '>=2.11.5'
           - distro: ubi8
             platform: instance-r-rh
-            ansible-version: '>=2.11.5'
           - distro: ubi9
             platform: instance-r-rh
-            ansible-version: '>=2.11.5'
 
     steps:
       - name: Check out the codebase
@@ -63,7 +60,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install 'ansible${{ matrix.ansible-version }}' molecule molecule-plugins[docker] docker
+        run: pip install -r requirements.txt
 
       - name: Run Molecule tests
         run: |

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,33 +1,30 @@
 ---
-dependency:
-  name: galaxy
-driver:
-  name: docker
-platforms:
-  - &instance
-    name: instance-r
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    capabilities:
-      - SYS_ADMIN
-    pre_build_image: true
-    platform: linux/amd64
-  - <<: *instance
-    name: instance-r-rh
-    image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
-    command: "/usr/sbin/init"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    user: root
-    privileged: true
-    platform: linux/amd64
-    capabilities:
-      - SYS_ADMIN
-provisioner:
-  name: ansible
-  playbooks:
-    prepare: prepare.yml
-    converge: converge.yml
-    verify: verify.yml
+  dependency:
+    name: galaxy
+  driver:
+    name: docker
+  platforms:
+    - &instance
+      name: instance-r
+      image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+      command: ${MOLECULE_DOCKER_COMMAND:-""}
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      capabilities:
+        - SYS_ADMIN
+      pre_build_image: true
+      platform: linux/amd64
+    - <<: *instance
+      name: instance-r-rh
+      image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
+      command: "/usr/sbin/init"
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      privileged: true
+      cgroupns_mode: host
+  provisioner:
+    name: ansible
+    playbooks:
+      prepare: prepare.yml
+      converge: converge.yml
+      verify: verify.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,6 +20,8 @@ platforms:
     command: "/usr/sbin/init"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    capabilities:
+      - SYS_ADMIN
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,11 @@ platforms:
     platform: linux/amd64
   - <<: *instance
     name: instance-r-rh
-    image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi8}/ubi-init"
+    image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
     command: "/usr/sbin/init"
+    platform: linux/amd64
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,6 @@ platforms:
     name: instance-r-rh
     image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
     command: "/usr/sbin/init"
-    platform: linux/amd64
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,7 @@ platforms:
     command: "/usr/sbin/init"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    capabilities:
-      - SYS_ADMIN
+    user: root
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,11 +16,10 @@ platforms:
     platform: linux/amd64
   - <<: *instance
     name: instance-r-rh
-    ANSIBLE_REMOTE_TMP: /tmp/.ansible/tmp
     image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
     command: "/usr/sbin/init"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     user: root
     privileged: true
     platform: linux/amd64
@@ -28,9 +27,6 @@ platforms:
       - SYS_ADMIN
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      remote_tmp: /tmp/ansible-tmp
   playbooks:
     prepare: prepare.yml
     converge: converge.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,10 +16,11 @@ platforms:
     platform: linux/amd64
   - <<: *instance
     name: instance-r-rh
+    ANSIBLE_REMOTE_TMP: /tmp/.ansible/tmp
     image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
     command: "/usr/sbin/init"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     user: root
     privileged: true
     platform: linux/amd64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,6 +28,9 @@ platforms:
       - SYS_ADMIN
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible-tmp
   playbooks:
     prepare: prepare.yml
     converge: converge.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,10 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     user: root
+    privileged: true
+    platform: linux/amd64
+    capabilities:
+      - SYS_ADMIN
 provisioner:
   name: ansible
   playbooks:

--- a/vars/_redhat-9.yml
+++ b/vars/_redhat-9.yml
@@ -1,7 +1,4 @@
 # vars file
 ---
-
-system_dependencies:
-  - gcc-gfortran
   
 r_download_url: "https://cdn.rstudio.com/r/rhel-9/pkgs"

--- a/vars/_redhat-9.yml
+++ b/vars/_redhat-9.yml
@@ -1,0 +1,7 @@
+# vars file
+---
+
+system_dependencies:
+  - gcc-gfortran
+  
+r_download_url: "https://cdn.rstudio.com/r/rhel-9/pkgs"


### PR DESCRIPTION
Issue #17

## Description
Added support for RHEL 9 by:

1. Creating a vars/_redhat-9.yml file to specify RHEL 9.
2. Updating molecule.yml to correctly mount the /sys/fs/cgroup volume with appropriate permissions to avoid errors.

These changes ensure that the Molecule test suite can successfully run on RHEL 9 instances.

## Definition of Done
- [x] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)

